### PR TITLE
Point macros 1.1 errors to the input item

### DIFF
--- a/mk/crates.mk
+++ b/mk/crates.mk
@@ -59,7 +59,7 @@ RUSTC_CRATES := rustc rustc_typeck rustc_mir rustc_borrowck rustc_resolve rustc_
                 rustc_trans rustc_back rustc_llvm rustc_privacy rustc_lint \
                 rustc_data_structures rustc_platform_intrinsics rustc_errors \
                 rustc_plugin rustc_metadata rustc_passes rustc_save_analysis \
-                rustc_const_eval rustc_const_math rustc_incremental
+                rustc_const_eval rustc_const_math rustc_incremental rustc_macro
 HOST_CRATES := syntax syntax_ext proc_macro syntax_pos $(RUSTC_CRATES) rustdoc fmt_macros \
 		flate arena graphviz rbml log serialize
 TOOLS := compiletest rustdoc rustc rustbook error_index_generator
@@ -99,7 +99,7 @@ DEPS_term := std
 DEPS_test := std getopts term native:rust_test_helpers
 
 DEPS_syntax := std term serialize log arena libc rustc_bitflags rustc_unicode rustc_errors syntax_pos
-DEPS_syntax_ext := syntax syntax_pos rustc_errors fmt_macros
+DEPS_syntax_ext := syntax syntax_pos rustc_errors fmt_macros rustc_macro
 DEPS_proc_macro := syntax syntax_pos rustc_plugin log
 DEPS_syntax_pos := serialize
 
@@ -118,11 +118,13 @@ DEPS_rustc_driver := arena flate getopts graphviz libc rustc rustc_back rustc_bo
                      rustc_trans rustc_privacy rustc_lint rustc_plugin \
                      rustc_metadata syntax_ext proc_macro \
                      rustc_passes rustc_save_analysis rustc_const_eval \
-                     rustc_incremental syntax_pos rustc_errors
+                     rustc_incremental syntax_pos rustc_errors rustc_macro
 DEPS_rustc_errors := log libc serialize syntax_pos
 DEPS_rustc_lint := rustc log syntax syntax_pos rustc_const_eval
 DEPS_rustc_llvm := native:rustllvm libc std rustc_bitflags
-DEPS_rustc_metadata := rustc syntax syntax_pos rustc_errors rbml rustc_const_math
+DEPS_rustc_macro := std syntax
+DEPS_rustc_metadata := rustc syntax syntax_pos rustc_errors rbml rustc_const_math \
+			rustc_macro syntax_ext
 DEPS_rustc_passes := syntax syntax_pos rustc core rustc_const_eval rustc_errors
 DEPS_rustc_mir := rustc syntax syntax_pos rustc_const_math rustc_const_eval rustc_bitflags
 DEPS_rustc_resolve := arena rustc log syntax syntax_pos rustc_errors

--- a/src/librustc/middle/dependency_format.rs
+++ b/src/librustc/middle/dependency_format.rs
@@ -139,8 +139,13 @@ fn calculate_type(sess: &session::Session,
             }
         }
 
-        // Everything else falls through below
-        config::CrateTypeExecutable | config::CrateTypeDylib => {},
+        // Everything else falls through below. This will happen either with the
+        // `-C prefer-dynamic` or because we're a rustc-macro crate. Note that
+        // rustc-macro crates are required to be dylibs, and they're currently
+        // required to link to libsyntax as well.
+        config::CrateTypeExecutable |
+        config::CrateTypeDylib |
+        config::CrateTypeRustcMacro => {},
     }
 
     let mut formats = FnvHashMap();

--- a/src/librustc/middle/reachable.rs
+++ b/src/librustc/middle/reachable.rs
@@ -138,7 +138,8 @@ impl<'a, 'tcx> ReachableContext<'a, 'tcx> {
     // Creates a new reachability computation context.
     fn new(tcx: TyCtxt<'a, 'tcx, 'tcx>) -> ReachableContext<'a, 'tcx> {
         let any_library = tcx.sess.crate_types.borrow().iter().any(|ty| {
-            *ty == config::CrateTypeRlib || *ty == config::CrateTypeDylib
+            *ty == config::CrateTypeRlib || *ty == config::CrateTypeDylib ||
+            *ty == config::CrateTypeRustcMacro
         });
         ReachableContext {
             tcx: tcx,

--- a/src/librustc/middle/weak_lang_items.rs
+++ b/src/librustc/middle/weak_lang_items.rs
@@ -70,6 +70,7 @@ fn verify(sess: &Session, items: &lang_items::LanguageItems) {
     let needs_check = sess.crate_types.borrow().iter().any(|kind| {
         match *kind {
             config::CrateTypeDylib |
+            config::CrateTypeRustcMacro |
             config::CrateTypeCdylib |
             config::CrateTypeExecutable |
             config::CrateTypeStaticlib => true,

--- a/src/librustc/session/config.rs
+++ b/src/librustc/session/config.rs
@@ -475,6 +475,7 @@ pub enum CrateType {
     CrateTypeRlib,
     CrateTypeStaticlib,
     CrateTypeCdylib,
+    CrateTypeRustcMacro,
 }
 
 #[derive(Clone, Hash)]
@@ -961,6 +962,9 @@ pub fn default_configuration(sess: &Session) -> ast::CrateConfig {
     }
     if sess.opts.debug_assertions {
         ret.push(attr::mk_word_item(InternedString::new("debug_assertions")));
+    }
+    if sess.opts.crate_types.contains(&CrateTypeRustcMacro) {
+        ret.push(attr::mk_word_item(InternedString::new("rustc_macro")));
     }
     return ret;
 }
@@ -1547,6 +1551,7 @@ pub fn parse_crate_types_from_list(list_list: Vec<String>) -> Result<Vec<CrateTy
                 "dylib"     => CrateTypeDylib,
                 "cdylib"    => CrateTypeCdylib,
                 "bin"       => CrateTypeExecutable,
+                "rustc-macro" => CrateTypeRustcMacro,
                 _ => {
                     return Err(format!("unknown crate type: `{}`",
                                        part));
@@ -1635,6 +1640,7 @@ impl fmt::Display for CrateType {
             CrateTypeRlib => "rlib".fmt(f),
             CrateTypeStaticlib => "staticlib".fmt(f),
             CrateTypeCdylib => "cdylib".fmt(f),
+            CrateTypeRustcMacro => "rustc-macro".fmt(f),
         }
     }
 }

--- a/src/librustc/session/mod.rs
+++ b/src/librustc/session/mod.rs
@@ -62,6 +62,7 @@ pub struct Session {
     pub entry_fn: RefCell<Option<(NodeId, Span)>>,
     pub entry_type: Cell<Option<config::EntryFnType>>,
     pub plugin_registrar_fn: Cell<Option<ast::NodeId>>,
+    pub derive_registrar_fn: Cell<Option<ast::NodeId>>,
     pub default_sysroot: Option<PathBuf>,
     // The name of the root source file of the crate, in the local file system.
     // The path is always expected to be absolute. `None` means that there is no
@@ -314,6 +315,12 @@ impl Session {
         format!("__rustc_plugin_registrar__{}_{}", svh, index.as_usize())
     }
 
+    pub fn generate_derive_registrar_symbol(&self,
+                                            svh: &Svh,
+                                            index: DefIndex) -> String {
+        format!("__rustc_derive_registrar__{}_{}", svh, index.as_usize())
+    }
+
     pub fn sysroot<'a>(&'a self) -> &'a Path {
         match self.opts.maybe_sysroot {
             Some (ref sysroot) => sysroot,
@@ -501,6 +508,7 @@ pub fn build_session_(sopts: config::Options,
         entry_fn: RefCell::new(None),
         entry_type: Cell::new(None),
         plugin_registrar_fn: Cell::new(None),
+        derive_registrar_fn: Cell::new(None),
         default_sysroot: default_sysroot,
         local_crate_source_file: local_crate_source_file,
         working_dir: env::current_dir().unwrap(),

--- a/src/librustc/ty/context.rs
+++ b/src/librustc/ty/context.rs
@@ -495,6 +495,10 @@ pub struct GlobalCtxt<'tcx> {
 
     /// Cache for layouts computed from types.
     pub layout_cache: RefCell<FnvHashMap<Ty<'tcx>, &'tcx Layout>>,
+
+    /// Map from function to the `#[derive]` mode that it's defining. Only used
+    /// by `rustc-macro` crates.
+    pub derive_macros: RefCell<NodeMap<token::InternedString>>,
 }
 
 impl<'tcx> GlobalCtxt<'tcx> {
@@ -756,6 +760,7 @@ impl<'a, 'gcx, 'tcx> TyCtxt<'a, 'gcx, 'tcx> {
             crate_name: token::intern_and_get_ident(crate_name),
             data_layout: data_layout,
             layout_cache: RefCell::new(FnvHashMap()),
+            derive_macros: RefCell::new(NodeMap()),
        }, f)
     }
 }

--- a/src/librustc_driver/derive_registrar.rs
+++ b/src/librustc_driver/derive_registrar.rs
@@ -1,0 +1,37 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use rustc::dep_graph::DepNode;
+use rustc::hir::intravisit::Visitor;
+use rustc::hir::map::Map;
+use rustc::hir;
+use syntax::ast;
+use syntax::attr;
+
+pub fn find(hir_map: &Map) -> Option<ast::NodeId> {
+    let _task = hir_map.dep_graph.in_task(DepNode::PluginRegistrar);
+    let krate = hir_map.krate();
+
+    let mut finder = Finder { registrar: None };
+    krate.visit_all_items(&mut finder);
+    finder.registrar
+}
+
+struct Finder {
+    registrar: Option<ast::NodeId>,
+}
+
+impl<'v> Visitor<'v> for Finder {
+    fn visit_item(&mut self, item: &hir::Item) {
+        if attr::contains_name(&item.attrs, "rustc_derive_registrar") {
+            self.registrar = Some(item.id);
+        }
+    }
+}

--- a/src/librustc_driver/lib.rs
+++ b/src/librustc_driver/lib.rs
@@ -107,7 +107,7 @@ pub mod test;
 pub mod driver;
 pub mod pretty;
 pub mod target_features;
-
+mod derive_registrar;
 
 const BUG_REPORT_URL: &'static str = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.\
                                       md#bug-reports";

--- a/src/librustc_macro/Cargo.toml
+++ b/src/librustc_macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["The Rust Project Developers"]
+name = "rustc_macro"
+version = "0.0.0"
+
+[lib]
+name = "rustc_macro"
+path = "lib.rs"
+crate-type = ["dylib"]
+
+[dependencies]
+syntax = { path = "../libsyntax" }

--- a/src/librustc_macro/lib.rs
+++ b/src/librustc_macro/lib.rs
@@ -1,0 +1,169 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! A support library for macro authors when defining new macros.
+//!
+//! This library, provided by the standard distribution, provides the types
+//! consumed in the interfaces of procedurally defined macro definitions.
+//! Currently the primary use of this crate is to provide the ability to define
+//! new custom derive modes through `#[rustc_macro_derive]`.
+//!
+//! Added recently as part of [RFC 1681] this crate is currently *unstable* and
+//! requires the `#![feature(rustc_macro)]` directive to use. Eventually,
+//! though, it is intended for this crate to become stable to use (perhaps under
+//! a different name).
+//!
+//! [RFC 1681]: https://github.com/rust-lang/rfcs/blob/master/text/1681-macros-1.1.md
+//!
+//! Note that this crate is intentionally very bare-bones currently. The main
+//! type, `TokenStream`, only supports `fmt::Display` and `FromStr`
+//! implementations, indicating that it can only go to and come from a string.
+//! This functionality is intended to be expanded over time as more surface
+//! area for macro authors is stabilized.
+
+#![crate_name = "rustc_macro"]
+#![unstable(feature = "rustc_macro_lib", issue = "27812")]
+#![crate_type = "rlib"]
+#![crate_type = "dylib"]
+#![cfg_attr(not(stage0), deny(warnings))]
+#![deny(missing_docs)]
+
+#![feature(rustc_private)]
+#![feature(staged_api)]
+#![feature(lang_items)]
+
+extern crate syntax;
+
+use std::fmt;
+use std::str::FromStr;
+
+use syntax::ast;
+use syntax::parse;
+use syntax::ptr::P;
+
+/// The main type provided by this crate, representing an abstract stream of
+/// tokens.
+///
+/// This is both the input and output of `#[rustc_macro_derive]` definitions.
+/// Currently it's required to be a list of valid Rust items, but this
+/// restriction may be lifted in the future.
+///
+/// The API of this type is intentionally bare-bones, but it'll be expanded over
+/// time!
+pub struct TokenStream {
+    inner: Vec<P<ast::Item>>,
+}
+
+/// Error returned from `TokenStream::from_str`.
+#[derive(Debug)]
+pub struct LexError {
+    _inner: (),
+}
+
+/// Permanently unstable internal implementation details of this crate. This
+/// should not be used.
+///
+/// These methods are used by the rest of the compiler to generate instances of
+/// `TokenStream` to hand to macro definitions, as well as consume the output.
+///
+/// Note that this module is also intentionally separate from the rest of the
+/// crate. This allows the `#[unstable]` directive below to naturally apply to
+/// all of the contents.
+#[unstable(feature = "rustc_macro_internals", issue = "27812")]
+#[doc(hidden)]
+pub mod __internal {
+    use std::cell::Cell;
+
+    use syntax::ast;
+    use syntax::ptr::P;
+    use syntax::parse::ParseSess;
+    use super::TokenStream;
+
+    pub fn new_token_stream(item: P<ast::Item>) -> TokenStream {
+        TokenStream { inner: vec![item] }
+    }
+
+    pub fn token_stream_items(stream: TokenStream) -> Vec<P<ast::Item>> {
+        stream.inner
+    }
+
+    pub trait Registry {
+        fn register_custom_derive(&mut self,
+                                  trait_name: &str,
+                                  expand: fn(TokenStream) -> TokenStream);
+    }
+
+    // Emulate scoped_thread_local!() here essentially
+    thread_local! {
+        static CURRENT_SESS: Cell<*const ParseSess> = Cell::new(0 as *const _);
+    }
+
+    pub fn set_parse_sess<F, R>(sess: &ParseSess, f: F) -> R
+        where F: FnOnce() -> R
+    {
+        struct Reset { prev: *const ParseSess }
+
+        impl Drop for Reset {
+            fn drop(&mut self) {
+                CURRENT_SESS.with(|p| p.set(self.prev));
+            }
+        }
+
+        CURRENT_SESS.with(|p| {
+            let _reset = Reset { prev: p.get() };
+            p.set(sess);
+            f()
+        })
+    }
+
+    pub fn with_parse_sess<F, R>(f: F) -> R
+        where F: FnOnce(&ParseSess) -> R
+    {
+        let p = CURRENT_SESS.with(|p| p.get());
+        assert!(!p.is_null());
+        f(unsafe { &*p })
+    }
+}
+
+impl FromStr for TokenStream {
+    type Err = LexError;
+
+    fn from_str(src: &str) -> Result<TokenStream, LexError> {
+        __internal::with_parse_sess(|sess| {
+            let src = src.to_string();
+            let cfg = Vec::new();
+            let name = "rustc-macro source code".to_string();
+            let mut parser = parse::new_parser_from_source_str(sess, cfg, name,
+                                                               src);
+            let mut ret = TokenStream { inner: Vec::new() };
+            loop {
+                match parser.parse_item() {
+                    Ok(Some(item)) => ret.inner.push(item),
+                    Ok(None) => return Ok(ret),
+                    Err(mut err) => {
+                        err.cancel();
+                        return Err(LexError { _inner: () })
+                    }
+                }
+            }
+        })
+    }
+}
+
+impl fmt::Display for TokenStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for item in self.inner.iter() {
+            let item = syntax::print::pprust::item_to_string(item);
+            try!(f.write_str(&item));
+            try!(f.write_str("\n"));
+        }
+        Ok(())
+    }
+}

--- a/src/librustc_metadata/Cargo.toml
+++ b/src/librustc_metadata/Cargo.toml
@@ -19,6 +19,8 @@ rustc_const_math = { path = "../librustc_const_math" }
 rustc_data_structures = { path = "../librustc_data_structures" }
 rustc_errors = { path = "../librustc_errors" }
 rustc_llvm = { path = "../librustc_llvm" }
+rustc_macro = { path = "../librustc_macro" }
 serialize = { path = "../libserialize" }
 syntax = { path = "../libsyntax" }
+syntax_ext = { path = "../libsyntax_ext" }
 syntax_pos = { path = "../libsyntax_pos" }

--- a/src/librustc_metadata/common.rs
+++ b/src/librustc_metadata/common.rs
@@ -234,6 +234,8 @@ pub fn rustc_version() -> String {
 
 pub const tag_panic_strategy: usize = 0x114;
 
+pub const tag_macro_derive_registrar: usize = 0x115;
+
 // NB: increment this if you change the format of metadata such that
 // rustc_version can't be found.
 pub const metadata_encoding_version : &'static [u8] = &[b'r', b'u', b's', b't', 0, 0, 0, 2];

--- a/src/librustc_metadata/cstore.rs
+++ b/src/librustc_metadata/cstore.rs
@@ -28,13 +28,13 @@ use rustc::hir::svh::Svh;
 use rustc::middle::cstore::ExternCrate;
 use rustc::session::config::PanicStrategy;
 use rustc_data_structures::indexed_vec::IndexVec;
-use rustc::util::nodemap::{FnvHashMap, NodeMap, NodeSet, DefIdMap};
+use rustc::util::nodemap::{FnvHashMap, NodeMap, NodeSet, DefIdMap, FnvHashSet};
 
 use std::cell::{RefCell, Ref, Cell};
 use std::rc::Rc;
 use std::path::PathBuf;
 use flate::Bytes;
-use syntax::ast;
+use syntax::ast::{self, Ident};
 use syntax::attr;
 use syntax::codemap;
 use syntax_pos;
@@ -115,6 +115,7 @@ pub struct CStore {
     pub inlined_item_cache: RefCell<DefIdMap<Option<CachedInlinedItem>>>,
     pub defid_for_inlined_node: RefCell<NodeMap<DefId>>,
     pub visible_parent_map: RefCell<DefIdMap<DefId>>,
+    pub used_for_derive_macro: RefCell<FnvHashSet<Ident>>,
 }
 
 impl CStore {
@@ -130,6 +131,7 @@ impl CStore {
             visible_parent_map: RefCell::new(FnvHashMap()),
             inlined_item_cache: RefCell::new(FnvHashMap()),
             defid_for_inlined_node: RefCell::new(FnvHashMap()),
+            used_for_derive_macro: RefCell::new(FnvHashSet()),
         }
     }
 
@@ -285,6 +287,14 @@ impl CStore {
     pub fn do_extern_mod_stmt_cnum(&self, emod_id: ast::NodeId) -> Option<ast::CrateNum>
     {
         self.extern_mod_crate_map.borrow().get(&emod_id).cloned()
+    }
+
+    pub fn was_used_for_derive_macros(&self, i: &ast::Item) -> bool {
+        self.used_for_derive_macro.borrow().contains(&i.ident)
+    }
+
+    pub fn add_used_for_derive_macros(&self, i: &ast::Item) {
+        self.used_for_derive_macro.borrow_mut().insert(i.ident);
     }
 }
 

--- a/src/librustc_metadata/decoder.rs
+++ b/src/librustc_metadata/decoder.rs
@@ -1398,6 +1398,11 @@ pub fn each_exported_macro<F>(data: &[u8], mut f: F) where
     }
 }
 
+pub fn get_derive_registrar_fn(data: &[u8]) -> Option<DefIndex> {
+    reader::maybe_get_doc(rbml::Doc::new(data), tag_macro_derive_registrar)
+        .map(|doc| DefIndex::from_u32(reader::doc_as_u32(doc)))
+}
+
 pub fn get_macro_span(doc: rbml::Doc) -> Span {
     let lo_doc = reader::get_doc(doc, tag_macro_def_span_lo);
     let lo = BytePos(reader::doc_as_u32(lo_doc));

--- a/src/librustc_metadata/lib.rs
+++ b/src/librustc_metadata/lib.rs
@@ -19,11 +19,13 @@
 
 #![feature(box_patterns)]
 #![feature(enumset)]
+#![feature(question_mark)]
 #![feature(quote)]
 #![feature(rustc_diagnostic_macros)]
+#![feature(rustc_macro_lib)]
+#![feature(rustc_macro_internals)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
-#![feature(question_mark)]
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate syntax;
@@ -33,12 +35,14 @@ extern crate flate;
 extern crate rbml;
 extern crate serialize as rustc_serialize; // used by deriving
 extern crate rustc_errors as errors;
+extern crate syntax_ext;
 
 #[macro_use]
 extern crate rustc;
 extern crate rustc_data_structures;
 extern crate rustc_back;
 extern crate rustc_llvm;
+extern crate rustc_macro;
 extern crate rustc_const_math;
 
 pub use rustc::middle;

--- a/src/librustc_metadata/macro_import.rs
+++ b/src/librustc_metadata/macro_import.rs
@@ -10,16 +10,25 @@
 
 //! Used by `rustc` when loading a crate with exported macros.
 
-use creader::CrateReader;
+use std::collections::HashSet;
+use std::env;
+use std::mem;
+
+use creader::{CrateReader, Macros};
 use cstore::CStore;
 
+use rustc::hir::def_id::DefIndex;
 use rustc::session::Session;
-use rustc::util::nodemap::{FnvHashSet, FnvHashMap};
-
-use syntax::parse::token;
+use rustc::util::nodemap::FnvHashMap;
+use rustc_back::dynamic_lib::DynamicLibrary;
+use rustc_macro::TokenStream;
+use rustc_macro::__internal::Registry;
 use syntax::ast;
 use syntax::attr;
+use syntax::ext::base::LoadedMacro;
 use syntax::ext;
+use syntax::parse::token;
+use syntax_ext::deriving::custom::CustomDerive;
 use syntax_pos::Span;
 
 pub struct MacroLoader<'a> {
@@ -47,7 +56,9 @@ pub fn call_bad_macro_reexport(a: &Session, b: Span) {
 pub type MacroSelection = FnvHashMap<token::InternedString, Span>;
 
 impl<'a> ext::base::MacroLoader for MacroLoader<'a> {
-    fn load_crate(&mut self, extern_crate: &ast::Item, allows_macros: bool) -> Vec<ast::MacroDef> {
+    fn load_crate(&mut self,
+                  extern_crate: &ast::Item,
+                  allows_macros: bool) -> Vec<LoadedMacro> {
         // Parse the attributes relating to macros.
         let mut import = Some(FnvHashMap());  // None => load all
         let mut reexport = FnvHashMap();
@@ -105,7 +116,7 @@ impl<'a> MacroLoader<'a> {
                        allows_macros: bool,
                        import: Option<MacroSelection>,
                        reexport: MacroSelection)
-                       -> Vec<ast::MacroDef> {
+                       -> Vec<LoadedMacro> {
         if let Some(sel) = import.as_ref() {
             if sel.is_empty() && reexport.is_empty() {
                 return Vec::new();
@@ -118,10 +129,11 @@ impl<'a> MacroLoader<'a> {
             return Vec::new();
         }
 
-        let mut macros = Vec::new();
-        let mut seen = FnvHashSet();
+        let mut macros = self.reader.read_macros(vi);
+        let mut ret = Vec::new();
+        let mut seen = HashSet::new();
 
-        for mut def in self.reader.read_exported_macros(vi) {
+        for mut def in macros.macro_rules.drain(..) {
             let name = def.ident.name.as_str();
 
             def.use_locally = match import.as_ref() {
@@ -132,8 +144,27 @@ impl<'a> MacroLoader<'a> {
             def.allow_internal_unstable = attr::contains_name(&def.attrs,
                                                               "allow_internal_unstable");
             debug!("load_macros: loaded: {:?}", def);
-            macros.push(def);
+            ret.push(LoadedMacro::Def(def));
             seen.insert(name);
+        }
+
+        if let Some(index) = macros.custom_derive_registrar {
+            // custom derive crates currently should not have any macro_rules!
+            // exported macros, enforced elsewhere
+            assert_eq!(ret.len(), 0);
+
+            if import.is_some() {
+                self.sess.span_err(vi.span, "`rustc-macro` crates cannot be \
+                                             selectively imported from, must \
+                                             use `#[macro_use]`");
+            }
+
+            if reexport.len() > 0 {
+                self.sess.span_err(vi.span, "`rustc-macro` crates cannot be \
+                                             reexported from");
+            }
+
+            self.load_derive_macros(vi.span, &macros, index, &mut ret);
         }
 
         if let Some(sel) = import.as_ref() {
@@ -152,6 +183,54 @@ impl<'a> MacroLoader<'a> {
             }
         }
 
-        macros
+        return ret
+    }
+
+    /// Load the custom derive macros into the list of macros we're loading.
+    ///
+    /// Note that this is intentionally similar to how we load plugins today,
+    /// but also intentionally separate. Plugins are likely always going to be
+    /// implemented as dynamic libraries, but we have a possible future where
+    /// custom derive (and other macro-1.1 style features) are implemented via
+    /// executables and custom IPC.
+    fn load_derive_macros(&mut self,
+                          span: Span,
+                          macros: &Macros,
+                          index: DefIndex,
+                          ret: &mut Vec<LoadedMacro>) {
+        // Make sure the path contains a / or the linker will search for it.
+        let path = macros.dylib.as_ref().unwrap();
+        let path = env::current_dir().unwrap().join(path);
+        let lib = match DynamicLibrary::open(Some(&path)) {
+            Ok(lib) => lib,
+            Err(err) => self.sess.span_fatal(span, &err),
+        };
+
+        let sym = self.sess.generate_derive_registrar_symbol(&macros.svh, index);
+        let registrar = unsafe {
+            let sym = match lib.symbol(&sym) {
+                Ok(f) => f,
+                Err(err) => self.sess.span_fatal(span, &err),
+            };
+            mem::transmute::<*mut u8, fn(&mut Registry)>(sym)
+        };
+
+        struct MyRegistrar<'a>(&'a mut Vec<LoadedMacro>);
+
+        impl<'a> Registry for MyRegistrar<'a> {
+            fn register_custom_derive(&mut self,
+                                      trait_name: &str,
+                                      expand: fn(TokenStream) -> TokenStream) {
+                let derive = Box::new(CustomDerive::new(expand));
+                self.0.push(LoadedMacro::CustomDerive(trait_name.to_string(),
+                                                      derive));
+            }
+        }
+
+        registrar(&mut MyRegistrar(ret));
+
+        // Intentionally leak the dynamic library. We can't ever unload it
+        // since the library can make things that will live arbitrarily long.
+        mem::forget(lib);
     }
 }

--- a/src/librustc_plugin/registry.rs
+++ b/src/librustc_plugin/registry.rs
@@ -156,7 +156,6 @@ impl<'a> Registry<'a> {
         self.llvm_passes.push(name.to_owned());
     }
 
-
     /// Register an attribute with an attribute type.
     ///
     /// Registered attributes will bypass the `custom_attribute` feature gate.

--- a/src/librustc_trans/back/linker.rs
+++ b/src/librustc_trans/back/linker.rs
@@ -243,7 +243,8 @@ impl<'a> Linker for GnuLinker<'a> {
         // exported symbols to ensure we don't expose any more. The object files
         // have far more public symbols than we actually want to export, so we
         // hide them all here.
-        if crate_type == CrateType::CrateTypeDylib {
+        if crate_type == CrateType::CrateTypeDylib ||
+           crate_type == CrateType::CrateTypeRustcMacro {
             return
         }
 
@@ -456,7 +457,8 @@ fn exported_symbols(scx: &SharedCrateContext,
 
     // See explanation in GnuLinker::export_symbols, for
     // why we don't ever need dylib symbols on non-MSVC.
-    if crate_type == CrateType::CrateTypeDylib {
+    if crate_type == CrateType::CrateTypeDylib ||
+       crate_type == CrateType::CrateTypeRustcMacro {
         if !scx.sess().target.target.options.is_like_msvc {
             return vec![];
         }

--- a/src/librustc_trans/back/symbol_names.rs
+++ b/src/librustc_trans/back/symbol_names.rs
@@ -188,6 +188,11 @@ impl<'a, 'tcx> Instance<'tcx> {
                 let idx = def_id.index;
                 return scx.sess().generate_plugin_registrar_symbol(svh, idx);
             }
+            if scx.sess().derive_registrar_fn.get() == Some(id) {
+                let svh = &scx.link_meta().crate_hash;
+                let idx = def_id.index;
+                return scx.sess().generate_derive_registrar_symbol(svh, idx);
+            }
         }
 
         // FIXME(eddyb) Precompute a custom symbol name based on attributes.

--- a/src/libsyntax/feature_gate.rs
+++ b/src/libsyntax/feature_gate.rs
@@ -47,7 +47,7 @@ macro_rules! setter {
 }
 
 macro_rules! declare_features {
-    ($((active, $feature: ident, $ver: expr, $issue: expr)),+) => {
+    ($((active, $feature: ident, $ver: expr, $issue: expr),)+) => {
         /// Represents active features that are currently being implemented or
         /// currently being considered for addition/removal.
         const ACTIVE_FEATURES: &'static [(&'static str, &'static str,
@@ -75,14 +75,14 @@ macro_rules! declare_features {
         }
     };
 
-    ($((removed, $feature: ident, $ver: expr, $issue: expr)),+) => {
+    ($((removed, $feature: ident, $ver: expr, $issue: expr),)+) => {
         /// Represents features which has since been removed (it was once Active)
         const REMOVED_FEATURES: &'static [(&'static str, &'static str, Option<u32>)] = &[
             $((stringify!($feature), $ver, $issue)),+
         ];
     };
 
-    ($((accepted, $feature: ident, $ver: expr, $issue: expr)),+) => {
+    ($((accepted, $feature: ident, $ver: expr, $issue: expr),)+) => {
         /// Those language feature has since been Accepted (it was once Active)
         const ACCEPTED_FEATURES: &'static [(&'static str, &'static str, Option<u32>)] = &[
             $((stringify!($feature), $ver, $issue)),+
@@ -288,7 +288,10 @@ declare_features! (
     (active, abi_sysv64, "1.13.0", Some(36167)),
 
     // Use the import semantics from RFC 1560.
-    (active, item_like_imports, "1.13.0", Some(35120))
+    (active, item_like_imports, "1.13.0", Some(35120)),
+
+    // Macros 1.1
+    (active, rustc_macro, "1.13.0", Some(35900)),
 );
 
 declare_features! (
@@ -302,7 +305,6 @@ declare_features! (
     (removed, struct_inherit, "1.0.0", None),
     (removed, test_removed_feature, "1.0.0", None),
     (removed, visible_private_types, "1.0.0", None),
-    (removed, unsafe_no_drop_flag, "1.0.0", None)
 );
 
 declare_features! (
@@ -330,7 +332,7 @@ declare_features! (
     (accepted, type_macros, "1.13.0", Some(27245)),
     (accepted, while_let, "1.0.0", None),
     // Allows `#[deprecated]` attribute
-    (accepted, deprecated, "1.9.0", Some(29935))
+    (accepted, deprecated, "1.9.0", Some(29935)),
 );
 // (changing above list without updating src/doc/reference.md makes @cmr sad)
 
@@ -543,6 +545,15 @@ pub const KNOWN_ATTRIBUTES: &'static [(&'static str, AttributeType, AttributeGat
                                    is an experimental feature",
                                   cfg_fn!(linked_from))),
 
+    ("rustc_macro_derive", Normal, Gated("rustc_macro",
+                                         "the `#[rustc_macro_derive]` attribute \
+                                          is an experimental feature",
+                                         cfg_fn!(rustc_macro))),
+
+    ("rustc_copy_clone_marker", Whitelisted, Gated("rustc_attrs",
+                                                   "internal implementation detail",
+                                                   cfg_fn!(rustc_attrs))),
+
     // FIXME: #14408 whitelist docs since rustdoc looks at them
     ("doc", Whitelisted, Ungated),
 
@@ -616,6 +627,7 @@ const GATED_CFGS: &'static [(&'static str, &'static str, fn(&Features) -> bool)]
     ("target_vendor", "cfg_target_vendor", cfg_fn!(cfg_target_vendor)),
     ("target_thread_local", "cfg_target_thread_local", cfg_fn!(cfg_target_thread_local)),
     ("target_has_atomic", "cfg_target_has_atomic", cfg_fn!(cfg_target_has_atomic)),
+    ("rustc_macro", "rustc_macro", cfg_fn!(rustc_macro)),
 ];
 
 #[derive(Debug, Eq, PartialEq)]

--- a/src/libsyntax_ext/Cargo.toml
+++ b/src/libsyntax_ext/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["dylib"]
 [dependencies]
 fmt_macros = { path = "../libfmt_macros" }
 log = { path = "../liblog" }
+rustc_errors = { path = "../librustc_errors" }
+rustc_macro = { path = "../librustc_macro" }
 syntax = { path = "../libsyntax" }
 syntax_pos = { path = "../libsyntax_pos" }
-rustc_errors = { path = "../librustc_errors" }

--- a/src/libsyntax_ext/deriving/custom.rs
+++ b/src/libsyntax_ext/deriving/custom.rs
@@ -53,6 +53,7 @@ impl MultiItemModifier for CustomDerive {
             }
         }
 
+        let input_span = item.span;
         let input = __internal::new_token_stream(item);
         let res = __internal::set_parse_sess(&ecx.parse_sess, || {
             let inner = self.inner;
@@ -77,9 +78,9 @@ impl MultiItemModifier for CustomDerive {
 
         // Right now we have no knowledge of spans at all in custom derive
         // macros, everything is just parsed as a string. Reassign all spans to
-        // the #[derive] attribute for better errors here.
+        // the input `item` for better errors here.
         item.into_iter().flat_map(|item| {
-            ChangeSpan { span: span }.fold_item(item)
+            ChangeSpan { span: input_span }.fold_item(item)
         }).map(Annotatable::Item).collect()
     }
 }

--- a/src/libsyntax_ext/deriving/custom.rs
+++ b/src/libsyntax_ext/deriving/custom.rs
@@ -1,0 +1,97 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::panic;
+
+use rustc_macro::{TokenStream, __internal};
+use syntax::ast::{self, ItemKind};
+use syntax::codemap::Span;
+use syntax::ext::base::*;
+use syntax::fold::{self, Folder};
+use errors::FatalError;
+
+pub struct CustomDerive {
+    inner: fn(TokenStream) -> TokenStream,
+}
+
+impl CustomDerive {
+    pub fn new(inner: fn(TokenStream) -> TokenStream) -> CustomDerive {
+        CustomDerive { inner: inner }
+    }
+}
+
+impl MultiItemModifier for CustomDerive {
+    fn expand(&self,
+              ecx: &mut ExtCtxt,
+              span: Span,
+              _meta_item: &ast::MetaItem,
+              item: Annotatable)
+              -> Vec<Annotatable> {
+        let item = match item {
+            Annotatable::Item(item) => item,
+            Annotatable::ImplItem(_) |
+            Annotatable::TraitItem(_) => {
+                ecx.span_err(span, "custom derive attributes may only be \
+                                    applied to struct/enum items");
+                return Vec::new()
+            }
+        };
+        match item.node {
+            ItemKind::Struct(..) |
+            ItemKind::Enum(..) => {}
+            _ => {
+                ecx.span_err(span, "custom derive attributes may only be \
+                                    applied to struct/enum items");
+                return Vec::new()
+            }
+        }
+
+        let input = __internal::new_token_stream(item);
+        let res = __internal::set_parse_sess(&ecx.parse_sess, || {
+            let inner = self.inner;
+            panic::catch_unwind(panic::AssertUnwindSafe(|| inner(input)))
+        });
+        let item = match res {
+            Ok(stream) => __internal::token_stream_items(stream),
+            Err(e) => {
+                let msg = "custom derive attribute panicked";
+                let mut err = ecx.struct_span_fatal(span, msg);
+                if let Some(s) = e.downcast_ref::<String>() {
+                    err.help(&format!("message: {}", s));
+                }
+                if let Some(s) = e.downcast_ref::<&'static str>() {
+                    err.help(&format!("message: {}", s));
+                }
+
+                err.emit();
+                panic!(FatalError);
+            }
+        };
+
+        // Right now we have no knowledge of spans at all in custom derive
+        // macros, everything is just parsed as a string. Reassign all spans to
+        // the #[derive] attribute for better errors here.
+        item.into_iter().flat_map(|item| {
+            ChangeSpan { span: span }.fold_item(item)
+        }).map(Annotatable::Item).collect()
+    }
+}
+
+struct ChangeSpan { span: Span }
+
+impl Folder for ChangeSpan {
+    fn new_span(&mut self, _sp: Span) -> Span {
+        self.span
+    }
+
+    fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac {
+        fold::noop_fold_mac(mac, self)
+    }
+}

--- a/src/libsyntax_ext/lib.rs
+++ b/src/libsyntax_ext/lib.rs
@@ -19,6 +19,8 @@
        html_root_url = "https://doc.rust-lang.org/nightly/")]
 #![cfg_attr(not(stage0), deny(warnings))]
 
+#![feature(rustc_macro_lib)]
+#![feature(rustc_macro_internals)]
 #![feature(rustc_private)]
 #![feature(staged_api)]
 
@@ -28,6 +30,7 @@ extern crate log;
 #[macro_use]
 extern crate syntax;
 extern crate syntax_pos;
+extern crate rustc_macro;
 extern crate rustc_errors as errors;
 
 use syntax::ext::base::{MacroExpanderFn, NormalTT};
@@ -43,6 +46,8 @@ mod env;
 mod format;
 mod log_syntax;
 mod trace_macros;
+
+pub mod rustc_macro_registrar;
 
 // for custom_derive
 pub mod deriving;

--- a/src/libsyntax_ext/rustc_macro_registrar.rs
+++ b/src/libsyntax_ext/rustc_macro_registrar.rs
@@ -1,0 +1,280 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::mem;
+
+use errors;
+use syntax::ast::{self, Ident, NodeId};
+use syntax::codemap::{ExpnInfo, NameAndSpan, MacroAttribute};
+use syntax::ext::base::{ExtCtxt, DummyMacroLoader};
+use syntax::ext::build::AstBuilder;
+use syntax::ext::expand::ExpansionConfig;
+use syntax::parse::ParseSess;
+use syntax::parse::token::{self, InternedString};
+use syntax::feature_gate::Features;
+use syntax::ptr::P;
+use syntax_pos::{Span, DUMMY_SP};
+use syntax::visit::{self, Visitor};
+
+use deriving;
+
+struct CustomDerive {
+    trait_name: InternedString,
+    function_name: Ident,
+    span: Span,
+}
+
+struct CollectCustomDerives<'a> {
+    derives: Vec<CustomDerive>,
+    in_root: bool,
+    handler: &'a errors::Handler,
+    is_rustc_macro_crate: bool,
+}
+
+pub fn modify(sess: &ParseSess,
+              mut krate: ast::Crate,
+              is_rustc_macro_crate: bool,
+              num_crate_types: usize,
+              handler: &errors::Handler,
+              features: &Features) -> ast::Crate {
+    let mut loader = DummyMacroLoader;
+    let mut cx = ExtCtxt::new(sess,
+                              Vec::new(),
+                              ExpansionConfig::default("rustc_macro".to_string()),
+                              &mut loader);
+
+    let mut collect = CollectCustomDerives {
+        derives: Vec::new(),
+        in_root: true,
+        handler: handler,
+        is_rustc_macro_crate: is_rustc_macro_crate,
+    };
+    visit::walk_crate(&mut collect, &krate);
+
+    if !is_rustc_macro_crate {
+        return krate
+    } else if !features.rustc_macro {
+        let mut err = handler.struct_err("the `rustc-macro` crate type is \
+                                          experimental");
+        err.help("add #![feature(rustc_macro)] to the crate attributes to \
+                  enable");
+        err.emit();
+    }
+
+    if num_crate_types > 1 {
+        handler.err("cannot mix `rustc-macro` crate type with others");
+    }
+
+    krate.module.items.push(mk_registrar(&mut cx, &collect.derives));
+
+    if krate.exported_macros.len() > 0 {
+        handler.err("cannot export macro_rules! macros from a `rustc-macro` \
+                     crate type currently");
+    }
+
+    return krate
+}
+
+impl<'a> CollectCustomDerives<'a> {
+    fn check_not_pub_in_root(&self, vis: &ast::Visibility, sp: Span) {
+        if self.is_rustc_macro_crate &&
+           self.in_root &&
+           *vis == ast::Visibility::Public {
+            self.handler.span_err(sp,
+                                  "`rustc-macro` crate types cannot \
+                                   export any items other than functions \
+                                   tagged with `#[rustc_macro_derive]` \
+                                   currently");
+        }
+    }
+}
+
+impl<'a> Visitor for CollectCustomDerives<'a> {
+    fn visit_item(&mut self, item: &ast::Item) {
+        // First up, make sure we're checking a bare function. If we're not then
+        // we're just not interested in this item.
+        //
+        // If we find one, try to locate a `#[rustc_macro_derive]` attribute on
+        // it.
+        match item.node {
+            ast::ItemKind::Fn(..) => {}
+            _ => {
+                self.check_not_pub_in_root(&item.vis, item.span);
+                return visit::walk_item(self, item)
+            }
+        }
+
+        let mut attrs = item.attrs.iter()
+                            .filter(|a| a.check_name("rustc_macro_derive"));
+        let attr = match attrs.next() {
+            Some(attr) => attr,
+            None => {
+                self.check_not_pub_in_root(&item.vis, item.span);
+                return visit::walk_item(self, item)
+            }
+        };
+
+        if let Some(a) = attrs.next() {
+            self.handler.span_err(a.span(), "multiple `#[rustc_macro_derive]` \
+                                             attributes found");
+        }
+
+        if !self.is_rustc_macro_crate {
+            self.handler.span_err(attr.span(),
+                                  "the `#[rustc_macro_derive]` attribute is \
+                                   only usable with crates of the `rustc-macro` \
+                                   crate type");
+        }
+
+        // Once we've located the `#[rustc_macro_derive]` attribute, verify
+        // that it's of the form `#[rustc_macro_derive(Foo)]`
+        let list = match attr.meta_item_list() {
+            Some(list) => list,
+            None => {
+                self.handler.span_err(attr.span(),
+                                      "attribute must be of form: \
+                                       #[rustc_macro_derive(TraitName)]");
+                return
+            }
+        };
+        if list.len() != 1 {
+            self.handler.span_err(attr.span(),
+                                  "attribute must only have one argument");
+            return
+        }
+        let attr = &list[0];
+        let trait_name = match attr.name() {
+            Some(name) => name,
+            _ => {
+                self.handler.span_err(attr.span(), "not a meta item");
+                return
+            }
+        };
+        if !attr.is_word() {
+            self.handler.span_err(attr.span(), "must only be one word");
+        }
+
+        if deriving::is_builtin_trait(&trait_name) {
+            self.handler.span_err(attr.span(),
+                                  "cannot override a built-in #[derive] mode");
+        }
+
+        if self.derives.iter().any(|d| d.trait_name == trait_name) {
+            self.handler.span_err(attr.span(),
+                                  "derive mode defined twice in this crate");
+        }
+
+        if self.in_root {
+            self.derives.push(CustomDerive {
+                span: item.span,
+                trait_name: trait_name,
+                function_name: item.ident,
+            });
+        } else {
+            let msg = "functions tagged with `#[rustc_macro_derive]` must \
+                       currently reside in the root of the crate";
+            self.handler.span_err(item.span, msg);
+        }
+
+        visit::walk_item(self, item);
+    }
+
+    fn visit_mod(&mut self, m: &ast::Mod, _s: Span, id: NodeId) {
+        let mut prev_in_root = self.in_root;
+        if id != ast::CRATE_NODE_ID {
+            prev_in_root = mem::replace(&mut self.in_root, false);
+        }
+        visit::walk_mod(self, m);
+        self.in_root = prev_in_root;
+    }
+
+    fn visit_mac(&mut self, mac: &ast::Mac) {
+        visit::walk_mac(self, mac)
+    }
+}
+
+// Creates a new module which looks like:
+//
+//      mod $gensym {
+//          extern crate rustc_macro;
+//
+//          use rustc_macro::__internal::Registry;
+//
+//          #[plugin_registrar]
+//          fn registrar(registrar: &mut Registry) {
+//              registrar.register_custom_derive($name_trait1, ::$name1);
+//              registrar.register_custom_derive($name_trait2, ::$name2);
+//              // ...
+//          }
+//      }
+fn mk_registrar(cx: &mut ExtCtxt,
+                custom_derives: &[CustomDerive]) -> P<ast::Item> {
+    let eid = cx.codemap().record_expansion(ExpnInfo {
+        call_site: DUMMY_SP,
+        callee: NameAndSpan {
+            format: MacroAttribute(token::intern("rustc_macro")),
+            span: None,
+            allow_internal_unstable: true,
+        }
+    });
+    let span = Span { expn_id: eid, ..DUMMY_SP };
+
+    let rustc_macro = token::str_to_ident("rustc_macro");
+    let krate = cx.item(span,
+                        rustc_macro,
+                        Vec::new(),
+                        ast::ItemKind::ExternCrate(None));
+
+    let __internal = token::str_to_ident("__internal");
+    let registry = token::str_to_ident("Registry");
+    let registrar = token::str_to_ident("registrar");
+    let register_custom_derive = token::str_to_ident("register_custom_derive");
+    let stmts = custom_derives.iter().map(|cd| {
+        let path = cx.path_global(cd.span, vec![cd.function_name]);
+        let trait_name = cx.expr_str(cd.span, cd.trait_name.clone());
+        (path, trait_name)
+    }).map(|(path, trait_name)| {
+        let registrar = cx.expr_ident(span, registrar);
+        let ufcs_path = cx.path(span, vec![rustc_macro, __internal, registry,
+                                           register_custom_derive]);
+        cx.expr_call(span,
+                     cx.expr_path(ufcs_path),
+                     vec![registrar, trait_name, cx.expr_path(path)])
+    }).map(|expr| {
+        cx.stmt_expr(expr)
+    }).collect::<Vec<_>>();
+
+    let path = cx.path(span, vec![rustc_macro, __internal, registry]);
+    let registrar_path = cx.ty_path(path);
+    let arg_ty = cx.ty_rptr(span, registrar_path, None, ast::Mutability::Mutable);
+    let func = cx.item_fn(span,
+                          registrar,
+                          vec![cx.arg(span, registrar, arg_ty)],
+                          cx.ty(span, ast::TyKind::Tup(Vec::new())),
+                          cx.block(span, stmts));
+
+    let derive_registrar = token::intern_and_get_ident("rustc_derive_registrar");
+    let derive_registrar = cx.meta_word(span, derive_registrar);
+    let derive_registrar = cx.attribute(span, derive_registrar);
+    let func = func.map(|mut i| {
+        i.attrs.push(derive_registrar);
+        i.vis = ast::Visibility::Public;
+        i
+    });
+    let module = cx.item_mod(span,
+                             span,
+                             ast::Ident::with_empty_ctxt(token::gensym("registrar")),
+                             Vec::new(),
+                             vec![krate, func]);
+    module.map(|mut i| {
+        i.vis = ast::Visibility::Public;
+        i
+    })
+}

--- a/src/rustc/Cargo.lock
+++ b/src/rustc/Cargo.lock
@@ -215,6 +215,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_macro"
+version = "0.0.0"
+dependencies = [
+ "syntax 0.0.0",
+]
+
+[[package]]
 name = "rustc_metadata"
 version = "0.0.0"
 dependencies = [
@@ -228,8 +235,10 @@ dependencies = [
  "rustc_data_structures 0.0.0",
  "rustc_errors 0.0.0",
  "rustc_llvm 0.0.0",
+ "rustc_macro 0.0.0",
  "serialize 0.0.0",
  "syntax 0.0.0",
+ "syntax_ext 0.0.0",
  "syntax_pos 0.0.0",
 ]
 
@@ -400,6 +409,7 @@ dependencies = [
  "fmt_macros 0.0.0",
  "log 0.0.0",
  "rustc_errors 0.0.0",
+ "rustc_macro 0.0.0",
  "syntax 0.0.0",
  "syntax_pos 0.0.0",
 ]

--- a/src/test/compile-fail-fulldeps/rustc-macro/append-impl.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/append-impl.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:append-impl.rs
+
+#![feature(rustc_macro)]
+#![allow(warnings)]
+
+#[macro_use]
+extern crate append_impl;
+
+trait Append {
+    fn foo(&self);
+}
+
+#[derive(PartialEq,
+         Append,
+         Eq)]
+//~^^ ERROR: the semantics of constant patterns is not yet settled
+struct A {
+    inner: u32,
+}
+
+fn main() {
+    A { inner: 3 }.foo();
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/at-the-root.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/at-the-root.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+
+extern crate rustc_macro;
+
+pub mod a { //~ `rustc-macro` crate types cannot export any items
+    use rustc_macro::TokenStream;
+
+    #[rustc_macro_derive(B)]
+    pub fn bar(a: TokenStream) -> TokenStream {
+    //~^ ERROR: must currently reside in the root of the crate
+        a
+    }
+}
+

--- a/src/test/compile-fail-fulldeps/rustc-macro/attribute.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/attribute.rs
@@ -1,0 +1,46 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+
+extern crate rustc_macro;
+
+#[rustc_macro_derive]
+//~^ ERROR: attribute must be of form: #[rustc_macro_derive(TraitName)]
+pub fn foo1(input: rustc_macro::TokenStream) -> rustc_macro::TokenStream {
+    input
+}
+
+#[rustc_macro_derive = "foo"]
+//~^ ERROR: attribute must be of form: #[rustc_macro_derive(TraitName)]
+pub fn foo2(input: rustc_macro::TokenStream) -> rustc_macro::TokenStream {
+    input
+}
+
+#[rustc_macro_derive(
+    a = "b"
+)]
+//~^^ ERROR: must only be one word
+pub fn foo3(input: rustc_macro::TokenStream) -> rustc_macro::TokenStream {
+    input
+}
+
+#[rustc_macro_derive(b, c)]
+//~^ ERROR: attribute must only have one argument
+pub fn foo4(input: rustc_macro::TokenStream) -> rustc_macro::TokenStream {
+    input
+}
+
+#[rustc_macro_derive(d(e))]
+//~^ ERROR: must only be one word
+pub fn foo5(input: rustc_macro::TokenStream) -> rustc_macro::TokenStream {
+    input
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/append-impl.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/append-impl.rs
@@ -1,0 +1,31 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![crate_type = "rustc-macro"]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(Append)]
+pub fn derive_a(input: TokenStream) -> TokenStream {
+    let mut input = input.to_string();
+    input.push_str("
+        impl Append for A {
+            fn foo(&self) {}
+        }
+    ");
+    input.parse().unwrap()
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-a-2.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-a-2.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![crate_type = "rustc-macro"]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn derive_a(input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-a.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-a.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![crate_type = "rustc-macro"]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn derive_a(input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-bad.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-bad.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// force-host
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![crate_type = "rustc-macro"]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn derive_a(_input: TokenStream) -> TokenStream {
+    "struct A { inner }".parse().unwrap()
+}
+

--- a/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-panic.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-panic.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// force-host
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![crate_type = "rustc-macro"]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn derive_a(_input: TokenStream) -> TokenStream {
+    panic!("nope!");
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-unstable-2.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-unstable-2.rs
@@ -1,0 +1,29 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![crate_type = "rustc-macro"]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(Unstable)]
+pub fn derive(_input: TokenStream) -> TokenStream {
+
+    "
+        #[rustc_foo]
+        fn foo() {}
+    ".parse().unwrap()
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-unstable.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/auxiliary/derive-unstable.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// force-host
+// no-prefer-dynamic
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![crate_type = "rustc-macro"]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(Unstable)]
+pub fn derive(_input: TokenStream) -> TokenStream {
+
+    "unsafe fn foo() -> u32 { ::std::intrinsics::init() }".parse().unwrap()
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/cannot-link.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/cannot-link.rs
@@ -1,0 +1,16 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-a.rs
+
+extern crate derive_a;
+//~^ ERROR: crates of the `rustc-macro` crate type cannot be linked at runtime
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/define-two.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/define-two.rs
@@ -1,0 +1,28 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn foo(input: TokenStream) -> TokenStream {
+    input
+}
+
+#[rustc_macro_derive(A)] //~ ERROR: derive mode defined twice in this crate
+pub fn bar(input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/derive-bad.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/derive-bad.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-bad.rs
+
+#![feature(rustc_macro)]
+
+#[macro_use]
+extern crate derive_bad;
+
+#[derive(
+    A
+)]
+//~^^ ERROR: custom derive attribute panicked
+//~| HELP: called `Result::unwrap()` on an `Err` value: LexError
+struct A;
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/derive-still-gated.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/derive-still-gated.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-a.rs
+
+#![feature(rustc_macro)]
+#![allow(warnings)]
+
+#[macro_use]
+extern crate derive_a;
+
+#[derive_A] //~ ERROR: attributes of the form `#[derive_*]` are reserved for the compiler
+struct A;
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable-2.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable-2.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-unstable-2.rs
+
+#![feature(rustc_macro)]
+#![allow(warnings)]
+
+#[macro_use]
+extern crate derive_unstable_2;
+
+#[derive(Unstable)]
+//~^ ERROR: reserved for internal compiler
+struct A;
+
+fn main() {
+    foo();
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/expand-to-unstable.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-unstable.rs
+
+#![feature(rustc_macro)]
+#![allow(warnings)]
+
+#[macro_use]
+extern crate derive_unstable;
+
+#[derive(Unstable)]
+//~^ ERROR: use of unstable library feature
+struct A;
+
+fn main() {
+    unsafe { foo(); }
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/export-macro.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/export-macro.rs
@@ -1,0 +1,19 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: cannot export macro_rules! macros from a `rustc-macro` crate
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+
+#[macro_export]
+macro_rules! foo {
+    ($e:expr) => ($e)
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/exports.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/exports.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rustc-macro"]
+#![allow(warnings)]
+
+pub fn a() {} //~ ERROR: cannot export any items
+pub struct B; //~ ERROR: cannot export any items
+pub enum C {} //~ ERROR: cannot export any items
+pub mod d {} //~ ERROR: cannot export any items
+
+mod e {}
+struct F;
+enum G {}
+fn h() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-1.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-1.rs
@@ -1,0 +1,13 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: the `rustc-macro` crate type is experimental
+
+#![crate_type = "rustc-macro"]

--- a/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-2.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-2.rs
@@ -1,0 +1,13 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate rustc_macro; //~ ERROR: use of unstable library feature
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-3.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-3.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rustc-macro"]
+
+#[rustc_macro_derive(Foo)] //~ ERROR: is an experimental feature
+pub fn foo() {
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-4.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-4.rs
@@ -1,0 +1,15 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-a.rs
+
+#[macro_use]
+extern crate derive_a;
+//~^ ERROR: loading custom derive macro crates is experimentally supported

--- a/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-5.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/feature-gate-5.rs
@@ -1,0 +1,12 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#[cfg(rustc_macro)] //~ ERROR: experimental and subject to change
+fn foo() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/import.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/import.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-a.rs
+
+#![feature(rustc_macro)]
+#![allow(warnings)]
+
+#[macro_use]
+extern crate derive_a;
+
+use derive_a::derive_a;
+//~^ ERROR: unresolved import `derive_a::derive_a`
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/load-panic.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/load-panic.rs
@@ -1,4 +1,4 @@
-// Copyright 2015 The Rust Project Developers. See the COPYRIGHT
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 // file at the top-level directory of this distribution and at
 // http://rust-lang.org/COPYRIGHT.
 //
@@ -8,13 +8,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
+// aux-build:derive-panic.rs
 
-#![feature(custom_derive)]
+#![feature(rustc_macro)]
 
-#[derive_Clone]
-struct Test;
+#[macro_use]
+extern crate derive_panic;
 
-pub fn main() {
-    Test.clone();
-}
+#[derive(A)]
+//~^ ERROR: custom derive attribute panicked
+//~| HELP: message: nope!
+struct Foo;
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/require-rustc-macro-crate-type.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/require-rustc-macro-crate-type.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![feature(rustc_macro)]
+
+extern crate rustc_macro;
+
+#[rustc_macro_derive(Foo)]
+//~^ ERROR: only usable with crates of the `rustc-macro` crate type
+pub fn foo(a: rustc_macro::TokenStream) -> rustc_macro::TokenStream {
+    a
+}
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/shadow-builtin.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/shadow-builtin.rs
@@ -1,0 +1,22 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(PartialEq)]
+//~^ ERROR: cannot override a built-in #[derive] mode
+pub fn foo(input: TokenStream) -> TokenStream {
+    input
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/shadow.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/shadow.rs
@@ -1,0 +1,21 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-a.rs
+// aux-build:derive-a-2.rs
+
+#![feature(rustc_macro)]
+
+#[macro_use]
+extern crate derive_a;
+#[macro_use]
+extern crate derive_a_2; //~ ERROR: cannot shadow existing derive mode `A`
+
+fn main() {}

--- a/src/test/compile-fail-fulldeps/rustc-macro/signature.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/signature.rs
@@ -1,0 +1,24 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+#![allow(warnings)]
+
+extern crate rustc_macro;
+
+#[rustc_macro_derive(A)]
+unsafe extern fn foo(a: i32, b: u32) -> u32 {
+    //~^ ERROR: mismatched types
+    //~| NOTE: expected normal fn, found unsafe fn
+    //~| NOTE: expected type `fn(rustc_macro::TokenStream) -> rustc_macro::TokenStream`
+    //~| NOTE: found type `unsafe extern "C" fn(i32, u32) -> u32 {foo}`
+    loop {}
+}

--- a/src/test/compile-fail-fulldeps/rustc-macro/two-crate-types-1.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/two-crate-types-1.rs
@@ -1,0 +1,14 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: cannot mix `rustc-macro` crate type with others
+
+#![crate_type = "rustc-macro"]
+#![crate_type = "rlib"]

--- a/src/test/compile-fail-fulldeps/rustc-macro/two-crate-types-2.rs
+++ b/src/test/compile-fail-fulldeps/rustc-macro/two-crate-types-2.rs
@@ -1,0 +1,12 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// error-pattern: cannot mix `rustc-macro` crate type with others
+// compile-flags: --crate-type rlib --crate-type rustc-macro

--- a/src/test/compile-fail/issue-32655.rs
+++ b/src/test/compile-fail/issue-32655.rs
@@ -13,7 +13,7 @@
 
 macro_rules! foo (
     () => (
-        #[derive_Clone] //~ WARN attributes of the form
+        #[derive_Clone] //~ ERROR attributes of the form
         struct T;
     );
 );
@@ -25,9 +25,8 @@ macro_rules! bar (
 foo!();
 
 bar!(
-    #[derive_Clone] //~ WARN attributes of the form
+    #[derive_Clone] //~ ERROR attributes of the form
     struct S;
 );
 
-#[rustc_error]
-fn main() {} //~ ERROR compilation successful
+fn main() {}

--- a/src/test/run-pass-fulldeps/rustc-macro/add-impl.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/add-impl.rs
@@ -1,0 +1,25 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:add-impl.rs
+
+#![feature(rustc_macro)]
+
+#[macro_use]
+extern crate add_impl;
+
+#[derive(AddImpl)]
+struct B;
+
+fn main() {
+    B.foo();
+    foo();
+    bar::foo();
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/auxiliary/add-impl.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/auxiliary/add-impl.rs
@@ -1,0 +1,33 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(AddImpl)]
+// #[cfg(rustc_macro)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    (input.to_string() + "
+        impl B {
+            fn foo(&self) {}
+        }
+
+        fn foo() {}
+
+        mod bar { pub fn foo() {} }
+    ").parse().unwrap()
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-a.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-a.rs
@@ -1,0 +1,27 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = input.to_string();
+    assert!(input.contains("struct A;"));
+    assert!(input.contains("#[derive(Eq, Copy, Clone)]"));
+    "#[derive(Eq, Copy, Clone)] struct A;".parse().unwrap()
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-atob.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-atob.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(AToB)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = input.to_string();
+    assert_eq!(input, "struct A;\n");
+    "struct B;".parse().unwrap()
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-ctod.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-ctod.rs
@@ -1,0 +1,26 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(CToD)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = input.to_string();
+    assert_eq!(input, "struct C;\n");
+    "struct D;".parse().unwrap()
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-same-struct.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/auxiliary/derive-same-struct.rs
@@ -1,0 +1,32 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+// compile-flags:--crate-type rustc-macro
+
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(AToB)]
+pub fn derive1(input: TokenStream) -> TokenStream {
+    println!("input1: {:?}", input.to_string());
+    assert_eq!(input.to_string(), "#[derive(BToC)]\nstruct A;\n");
+    "#[derive(BToC)] struct B;".parse().unwrap()
+}
+
+#[rustc_macro_derive(BToC)]
+pub fn derive2(input: TokenStream) -> TokenStream {
+    assert_eq!(input.to_string(), "struct B;\n");
+    "struct C;".parse().unwrap()
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/auxiliary/expand-with-a-macro.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/auxiliary/expand-with-a-macro.rs
@@ -1,0 +1,36 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// no-prefer-dynamic
+
+#![crate_type = "rustc-macro"]
+#![feature(rustc_macro)]
+#![feature(rustc_macro_lib)]
+#![deny(warnings)]
+
+extern crate rustc_macro;
+
+use rustc_macro::TokenStream;
+
+#[rustc_macro_derive(A)]
+pub fn derive(input: TokenStream) -> TokenStream {
+    let input = input.to_string();
+    assert!(input.contains("struct A;"));
+    r#"
+        struct A;
+
+        impl A {
+            fn a(&self) {
+                panic!("hello");
+            }
+        }
+    "#.parse().unwrap()
+}
+

--- a/src/test/run-pass-fulldeps/rustc-macro/derive-same-struct.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/derive-same-struct.rs
@@ -1,0 +1,23 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-same-struct.rs
+
+#![feature(rustc_macro)]
+
+#[macro_use]
+extern crate derive_same_struct;
+
+#[derive(AToB, BToC)]
+struct A;
+
+fn main() {
+    C;
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/expand-with-a-macro.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/expand-with-a-macro.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:expand-with-a-macro.rs
+// ignore-stage1
+
+#![feature(rustc_macro)]
+#![deny(warnings)]
+
+#[macro_use]
+extern crate expand_with_a_macro;
+
+use std::panic;
+
+#[derive(A)]
+struct A;
+
+fn main() {
+    assert!(panic::catch_unwind(|| {
+        A.a();
+    }).is_err());
+}
+

--- a/src/test/run-pass-fulldeps/rustc-macro/load-two.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/load-two.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-atob.rs
+// aux-build:derive-ctod.rs
+
+#![feature(rustc_macro)]
+
+#[macro_use]
+extern crate derive_atob;
+#[macro_use]
+extern crate derive_ctod;
+
+#[derive(AToB)]
+struct A;
+
+#[derive(CToD)]
+struct C;
+
+fn main() {
+    B;
+    D;
+}

--- a/src/test/run-pass-fulldeps/rustc-macro/smoke.rs
+++ b/src/test/run-pass-fulldeps/rustc-macro/smoke.rs
@@ -1,0 +1,29 @@
+// Copyright 2016 The Rust Project Developers. See the COPYRIGHT
+// file at the top-level directory of this distribution and at
+// http://rust-lang.org/COPYRIGHT.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+// aux-build:derive-a.rs
+// ignore-stage1
+
+#![feature(rustc_macro)]
+
+#[macro_use]
+extern crate derive_a;
+
+#[derive(Debug, PartialEq, A, Eq, Copy, Clone)]
+struct A;
+
+fn main() {
+    A;
+    assert_eq!(A, A);
+    A.clone();
+    let a = A;
+    let _c = a;
+    let _d = a;
+}

--- a/src/test/run-pass/associated-types-normalize-unifield-struct.rs
+++ b/src/test/run-pass/associated-types-normalize-unifield-struct.rs
@@ -11,9 +11,6 @@
 // Regression test for issue #21010: Normalize associated types in
 // various special paths in the `type_is_immediate` function.
 
-
-// pretty-expanded FIXME #23616
-
 pub trait OffsetState: Sized {}
 pub trait Offset {
     type State: OffsetState;

--- a/src/test/run-pass/builtin-superkinds-in-metadata.rs
+++ b/src/test/run-pass/builtin-superkinds-in-metadata.rs
@@ -13,8 +13,6 @@
 
 // Tests (correct) usage of trait super-builtin-kinds cross-crate.
 
-// pretty-expanded FIXME #23616
-
 extern crate trait_superkinds_in_metadata;
 use trait_superkinds_in_metadata::{RequiresRequiresShareAndSend, RequiresShare};
 use trait_superkinds_in_metadata::RequiresCopy;

--- a/src/test/run-pass/coherence-impl-in-fn.rs
+++ b/src/test/run-pass/coherence-impl-in-fn.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 pub fn main() {
     #[derive(Copy, Clone)]
     enum x { foo }

--- a/src/test/run-pass/deriving-bounds.rs
+++ b/src/test/run-pass/deriving-bounds.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #[derive(Copy, Clone)]
 struct Test;
 

--- a/src/test/run-pass/issue-20797.rs
+++ b/src/test/run-pass/issue-20797.rs
@@ -10,8 +10,6 @@
 
 // Regression test for #20797.
 
-// pretty-expanded FIXME #23616
-
 #![feature(question_mark)]
 
 use std::default::Default;

--- a/src/test/run-pass/issue-2288.rs
+++ b/src/test/run-pass/issue-2288.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #![allow(unknown_features)]
 #![feature(box_syntax)]
 

--- a/src/test/run-pass/sync-send-iterators-in-libcollections.rs
+++ b/src/test/run-pass/sync-send-iterators-in-libcollections.rs
@@ -8,8 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// pretty-expanded FIXME #23616
-
 #![allow(warnings)]
 #![feature(collections)]
 #![feature(drain, enumset, collections_bound, btree_range, vecmap)]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/36218.

Before:

``` rust
error[E0106]: missing lifetime specifier
  --> src/main.rs:10:10
   |
10 | #[derive(Serialize, Deserialize)]
   |          ^ expected lifetime parameter

error[E0038]: the trait `T` cannot be made into an object
  --> src/main.rs:15:15
   |
15 | #[derive(Serialize, Deserialize)]
   |          ^^^^^^^^^^ the trait `T` cannot be made into an object
```

After:

``` rust
error[E0106]: missing lifetime specifier
  --> src/main.rs:11:1
   |
11 | struct A {
   | ^ expected lifetime parameter

error[E0038]: the trait `T` cannot be made into an object
  --> src/main.rs:16:1
   |
16 | struct B<'a> {
   | ^ the trait `T` cannot be made into an object
```
